### PR TITLE
RuboCop config-related updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,3 @@ Layout/HashAlignment:
 # Checks if examples contain too many `expect` calls.
 RSpec/MultipleExpectations:
   Max: 2
-
-# Enforces the use of either `#alias` or `#alias_method`.
-Style/Alias:
-  EnforcedStyle: prefer_alias_method

--- a/lib/sprockets/sass_embedded/sass_processor.rb
+++ b/lib/sprockets/sass_embedded/sass_processor.rb
@@ -18,15 +18,16 @@ module Sprockets
           @functions
             .public_instance_methods
             .each_with_object({}) do |symbol, obj|
-              parameters = instance.method(symbol)
-                                   .parameters
-                                   .filter_map { |parameter| "$#{parameter.last}" if parameter.first == :req }
+              parameters = instance
+                             .method(symbol)
+                             .parameters
+                             .filter_map { |parameter| "$#{parameter.last}" if parameter.first == :req }
 
               obj["#{symbol}(#{parameters.join(', ')})"] = ->(args) { instance.public_send(symbol, *args) }
             end
         end
 
-        alias_method :to_h, :to_hash
+        alias to_h to_hash
 
         private
 


### PR DESCRIPTION
- Update RuboCop configuration
- Update formatting, use `alias` instead of `alias_method`
